### PR TITLE
fix: ローディング表示の不具合修正・入れ替えボタン削除 ＋ feat: 翻訳元言語タグの付与機能を追加

### DIFF
--- a/index.html
+++ b/index.html
@@ -28,11 +28,16 @@
         font-size: 1.25rem;
       }
 
+      /* レイアウトを中央に固定しつつ、はみ出さないようにする */
       .container {
+        width: 100%;
+        max-width: 900px; /* 必要に応じて調整 */
+        margin: 0 auto;
         display: flex;
         flex-direction: row;
         gap: 1rem;
         padding: 1rem;
+        box-sizing: border-box;
       }
 
       .column {
@@ -40,6 +45,7 @@
         display: flex;
         flex-direction: column;
         gap: 0.5rem;
+        min-width: 0; /* フレックスで縮めた際、テキスト領域がはみ出さないように */
       }
 
       label {
@@ -87,6 +93,7 @@
         overflow-y: auto;
         background-color: #f7f7f7;
         color: #444;
+        box-sizing: border-box;
       }
 
       /* ローディング表示（テキスト＋アニメーション） */
@@ -163,15 +170,15 @@
       <h1>SCPタグ翻訳ツール</h1>
     </header>
 
+    <!-- メインの2カラム: 翻訳元 / 翻訳先 -->
     <div class="container">
       <!-- 左カラム: 翻訳元 -->
       <div class="column">
         <label for="sourceLang">翻訳元言語</label>
         <select id="sourceLang">
-          <!-- 現状は英語(en)のみ -->
+          <!-- 今は英語(en)のみ対応 -->
           <option value="en" selected>English (en)</option>
-
-          <!-- 以下は将来のための候補。コメントアウトして未表示にする。
+          <!-- 以下は将来用。コメントアウトしておく
         <option value="cn">中文 (cn)</option>
         <option value="cs">Česky (cs)</option>
         <option value="de">Deutsch (de)</option>
@@ -196,10 +203,9 @@
       <div class="column">
         <label for="targetLang">翻訳先言語</label>
         <select id="targetLang">
-          <!-- 現状は日本語(jp)のみ -->
+          <!-- 今は日本語(jp)のみ対応 -->
           <option value="jp" selected>日本語 (jp)</option>
-
-          <!-- 今後の拡張用にコメントアウト
+          <!-- 以下は将来用
         <option value="en">English (en)</option>
         <option value="cn">中文 (cn)</option>
         <option value="cs">Česky (cs)</option>
@@ -224,8 +230,6 @@
         ></textarea>
 
         <div class="buttons">
-          <!-- 翻訳元/先 入れ替えボタン -->
-          <button class="button" id="btnSwap">入れ替え</button>
           <!-- コピー ボタン -->
           <button class="button" id="btnCopy">コピー</button>
         </div>
@@ -233,7 +237,7 @@
     </div>
 
     <!-- ログ表示欄 -->
-    <div class="container">
+    <div class="container" style="flex-direction: column">
       <div class="column">
         <label>ログ</label>
         <div id="logArea" aria-readonly="true"></div>
@@ -254,7 +258,7 @@
 
       window.addEventListener("DOMContentLoaded", () => {
         setupUI();
-        doTranslate(); // 初期表示
+        doTranslate(); // 初期ロード時に翻訳実行
       });
 
       function setupUI() {
@@ -268,12 +272,6 @@
           .getElementById("sourceText")
           .addEventListener("input", doTranslate);
 
-        // 入れ替えボタン
-        document.getElementById("btnSwap").addEventListener("click", () => {
-          swapLanguages();
-          doTranslate();
-        });
-
         // コピー ボタン
         document
           .getElementById("btnCopy")
@@ -286,28 +284,28 @@
       function doTranslate() {
         clearLog();
 
+        // 一旦ローディング表示をON
+        showLoading(true);
+
         const srcLang = document.getElementById("sourceLang").value;
         const tgtLang = document.getElementById("targetLang").value;
         const mapKey = `${srcLang}_to_${tgtLang}`;
-        const inputStr = document.getElementById("sourceText").value.trim();
 
-        // 入力が空ならクリア
+        const inputStr = document.getElementById("sourceText").value.trim();
         if (!inputStr) {
+          // 入力が空の場合は翻訳結果もクリアし、ローディングOFF
           document.getElementById("targetText").value = "";
+          showLoading(false);
           return;
         }
 
-        // ローディング表示
-        showLoading(true);
-
-        // キャッシュ済みか確認
+        // すでにキャッシュ済みかチェック
         if (dictionaryCache[mapKey]) {
           doTranslationWithDictionary(dictionaryCache[mapKey], inputStr);
           showLoading(false);
         } else {
-          // 該当ファイルを読み込み
+          // 辞書ファイルを読み込み
           const url = `./dictionaries/${mapKey}.json`;
-
           fetch(url)
             .then((res) => {
               if (!res.ok) {
@@ -327,20 +325,14 @@
               document.getElementById("targetText").value = "";
             })
             .finally(() => {
+              // ローディング表示OFF
               showLoading(false);
             });
         }
       }
 
       /**
-       * ローディング表示ON/OFF
-       */
-      function showLoading(isLoading) {
-        loadingIndicator.style.display = isLoading ? "flex" : "none";
-      }
-
-      /**
-       * 指定の辞書データで実翻訳を行う
+       * 辞書を使って実翻訳
        */
       function doTranslationWithDictionary(dictionary, inputStr) {
         // スペース区切り＆連結タグ対応
@@ -351,7 +343,6 @@
           allTags = allTags.concat(splitted);
         });
 
-        // 結果をまとめる
         const translatedList = [];
         const skippedList = [];
 
@@ -368,10 +359,7 @@
           }
         });
 
-        // 出力
         document.getElementById("targetText").value = translatedList.join(" ");
-
-        // ログ表示
         if (skippedList.length > 0) {
           setLog(
             "【注意】以下のタグはスキップされました：\n" +
@@ -384,6 +372,7 @@
        * 連結タグの最長一致分割
        */
       function splitConcatenatedTags(token, dictionary) {
+        // 「長いキーを優先」マッチ
         const dictKeys = Object.keys(dictionary).sort(
           (a, b) => b.length - a.length
         );
@@ -403,7 +392,7 @@
             }
           }
           if (!matched) {
-            // 未定義の残り部分
+            // どのキーにもマッチしない -> 残りは未定義
             result.push(remaining);
             remaining = "";
           }
@@ -412,15 +401,10 @@
       }
 
       /**
-       * 翻訳元/翻訳先を入れ替える
+       * ローディング表示の制御
        */
-      function swapLanguages() {
-        const sourceSelect = document.getElementById("sourceLang");
-        const targetSelect = document.getElementById("targetLang");
-
-        const tmp = sourceSelect.value;
-        sourceSelect.value = targetSelect.value;
-        targetSelect.value = tmp;
+      function showLoading(isLoading) {
+        loadingIndicator.style.display = isLoading ? "flex" : "none";
       }
 
       /**
@@ -448,7 +432,7 @@
       }
 
       /**
-       * ログを追加表示
+       * ログにメッセージ追加
        */
       function setLog(message) {
         const logArea = document.getElementById("logArea");

--- a/index.html
+++ b/index.html
@@ -5,7 +5,6 @@
     <title>SCPタグ翻訳ツール</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
 
-    <!-- CSS部分（ダークモード・レスポンシブ・ローディング表示など） -->
     <style>
       /* ベーススタイル */
       body {
@@ -28,10 +27,9 @@
         font-size: 1.25rem;
       }
 
-      /* レイアウトを中央に固定しつつ、はみ出さないようにする */
       .container {
         width: 100%;
-        max-width: 900px; /* 必要に応じて調整 */
+        max-width: 900px; /* ログ領域のはみ出しを防止 */
         margin: 0 auto;
         display: flex;
         flex-direction: row;
@@ -45,7 +43,7 @@
         display: flex;
         flex-direction: column;
         gap: 0.5rem;
-        min-width: 0; /* フレックスで縮めた際、テキスト領域がはみ出さないように */
+        min-width: 0; /* フレックス縮小時に要素がはみ出さないように */
       }
 
       label {
@@ -105,6 +103,7 @@
         display: flex;
         align-items: center;
       }
+
       .spinner {
         width: 20px;
         height: 20px;
@@ -114,6 +113,7 @@
         animation: spin 1s linear infinite;
         margin-right: 8px;
       }
+
       @keyframes spin {
         0% {
           transform: rotate(0deg);
@@ -157,7 +157,7 @@
         }
       }
 
-      /* スマホなど画面幅が狭い場合: 縦配置に切り替え */
+      /* 画面幅が狭い場合: 縦配置に切り替え */
       @media (max-width: 768px) {
         .container {
           flex-direction: column;
@@ -172,13 +172,12 @@
 
     <!-- メインの2カラム: 翻訳元 / 翻訳先 -->
     <div class="container">
-      <!-- 左カラム: 翻訳元 -->
       <div class="column">
         <label for="sourceLang">翻訳元言語</label>
         <select id="sourceLang">
           <!-- 今は英語(en)のみ対応 -->
           <option value="en" selected>English (en)</option>
-          <!-- 以下は将来用。コメントアウトしておく
+          <!-- 将来的には以下を追加（コメントアウト中）
         <option value="cn">中文 (cn)</option>
         <option value="cs">Česky (cs)</option>
         <option value="de">Deutsch (de)</option>
@@ -199,13 +198,12 @@
         <textarea id="sourceText" placeholder="翻訳したいタグを入力"></textarea>
       </div>
 
-      <!-- 右カラム: 翻訳先 -->
       <div class="column">
         <label for="targetLang">翻訳先言語</label>
         <select id="targetLang">
           <!-- 今は日本語(jp)のみ対応 -->
           <option value="jp" selected>日本語 (jp)</option>
-          <!-- 以下は将来用
+          <!-- 将来的には以下を追加（コメントアウト中）
         <option value="en">English (en)</option>
         <option value="cn">中文 (cn)</option>
         <option value="cs">Česky (cs)</option>
@@ -253,12 +251,32 @@
     <script>
       "use strict";
 
-      const dictionaryCache = {}; // ペアごとの辞書をキャッシュ
+      // 対応可能な言語支部タグ一覧
+      const recognizedLangs = [
+        "cn",
+        "cs",
+        "de",
+        "en",
+        "es",
+        "fr",
+        "it",
+        "jp",
+        "ko",
+        "pl",
+        "pt",
+        "ru",
+        "th",
+        "ua",
+        "vn",
+        "zh",
+      ];
+
+      const dictionaryCache = {}; // ペアごとの辞書キャッシュ
       const loadingIndicator = document.getElementById("loadingIndicator");
 
       window.addEventListener("DOMContentLoaded", () => {
         setupUI();
-        doTranslate(); // 初期ロード時に翻訳実行
+        doTranslate(); // ページ読み込み時に1度実行
       });
 
       function setupUI() {
@@ -271,8 +289,6 @@
         document
           .getElementById("sourceText")
           .addEventListener("input", doTranslate);
-
-        // コピー ボタン
         document
           .getElementById("btnCopy")
           .addEventListener("click", copyResult);
@@ -283,28 +299,30 @@
        */
       function doTranslate() {
         clearLog();
-
-        // 一旦ローディング表示をON
         showLoading(true);
 
         const srcLang = document.getElementById("sourceLang").value;
         const tgtLang = document.getElementById("targetLang").value;
         const mapKey = `${srcLang}_to_${tgtLang}`;
-
         const inputStr = document.getElementById("sourceText").value.trim();
+
         if (!inputStr) {
-          // 入力が空の場合は翻訳結果もクリアし、ローディングOFF
+          // 入力が空のときは翻訳結果をクリアし、ローディング非表示
           document.getElementById("targetText").value = "";
           showLoading(false);
           return;
         }
 
-        // すでにキャッシュ済みかチェック
+        // すでに読み込み済みかどうか
         if (dictionaryCache[mapKey]) {
-          doTranslationWithDictionary(dictionaryCache[mapKey], inputStr);
+          doTranslationWithDictionary(
+            dictionaryCache[mapKey],
+            inputStr,
+            srcLang
+          );
           showLoading(false);
         } else {
-          // 辞書ファイルを読み込み
+          // 辞書ファイルをfetch
           const url = `./dictionaries/${mapKey}.json`;
           fetch(url)
             .then((res) => {
@@ -315,29 +333,31 @@
             })
             .then((data) => {
               dictionaryCache[mapKey] = data;
-              doTranslationWithDictionary(data, inputStr);
+              doTranslationWithDictionary(data, inputStr, srcLang);
             })
             .catch((err) => {
               setLog(
-                `【エラー】未対応ペア (${mapKey}) です。辞書ファイルの読み込みに失敗。`
+                `【エラー】未対応ペア (${mapKey}) です。辞書ファイル読み込みに失敗。`
               );
               console.error(err);
               document.getElementById("targetText").value = "";
             })
             .finally(() => {
-              // ローディング表示OFF
               showLoading(false);
             });
         }
       }
 
       /**
-       * 辞書を使って実翻訳
+       * 辞書データで実際の翻訳を行う
+       * @param {object} dictionary - 翻訳用辞書
+       * @param {string} inputStr - ユーザー入力（タグ文字列）
+       * @param {string} srcLang - 翻訳元言語
        */
-      function doTranslationWithDictionary(dictionary, inputStr) {
-        // スペース区切り＆連結タグ対応
+      function doTranslationWithDictionary(dictionary, inputStr, srcLang) {
         const tokens = inputStr.split(/\s+/);
         let allTags = [];
+
         tokens.forEach((token) => {
           const splitted = splitConcatenatedTags(token, dictionary);
           allTags = allTags.concat(splitted);
@@ -359,7 +379,20 @@
           }
         });
 
+        // ---- 支部タグの追加（翻訳元言語をタグに含める）----
+        // 例: srcLang="en" なら "en" を出力に追加
+        if (recognizedLangs.includes(srcLang)) {
+          // 二重に入るのを避けたいなら、以下のように重複チェックをする
+          if (!translatedList.includes(srcLang)) {
+            // 先頭に追加
+            translatedList.unshift(srcLang);
+          }
+        }
+
+        // 結果をテキストエリアに表示
         document.getElementById("targetText").value = translatedList.join(" ");
+
+        // スキップのログ
         if (skippedList.length > 0) {
           setLog(
             "【注意】以下のタグはスキップされました：\n" +
@@ -372,7 +405,7 @@
        * 連結タグの最長一致分割
        */
       function splitConcatenatedTags(token, dictionary) {
-        // 「長いキーを優先」マッチ
+        // まず辞書キーを長さ降順でソート
         const dictKeys = Object.keys(dictionary).sort(
           (a, b) => b.length - a.length
         );
@@ -392,19 +425,12 @@
             }
           }
           if (!matched) {
-            // どのキーにもマッチしない -> 残りは未定義
+            // どのキーにもマッチしない -> 残り全て未定義として処理
             result.push(remaining);
             remaining = "";
           }
         }
         return result;
-      }
-
-      /**
-       * ローディング表示の制御
-       */
-      function showLoading(isLoading) {
-        loadingIndicator.style.display = isLoading ? "flex" : "none";
       }
 
       /**
@@ -425,6 +451,13 @@
       }
 
       /**
+       * ローディング表示の制御
+       */
+      function showLoading(isLoading) {
+        loadingIndicator.style.display = isLoading ? "flex" : "none";
+      }
+
+      /**
        * ログをクリア
        */
       function clearLog() {
@@ -432,7 +465,7 @@
       }
 
       /**
-       * ログにメッセージ追加
+       * ログにメッセージを追記
        */
       function setLog(message) {
         const logArea = document.getElementById("logArea");


### PR DESCRIPTION
このPRでは、次の2コミットをまとめて反映しています。

1. fix: ローディング表示が消えない不具合の修正・入れ替えボタン削除・ログ領域のレイアウト改善
   - 翻訳テキストが空の場合にもローディングが消えず表示される問題を修正
   - 入れ替えボタンを完全に削除
   - ログ表示領域が画面の右端にはみ出す問題を解消

2. feat: 翻訳元の支部タグを翻訳結果に付与するロジックを実装
   - recognizedLangs 配列を導入し、翻訳元が対応言語であれば翻訳結果にその支部タグ（例: en, jp など）を追加
   - 非使用タグや未定義タグの扱いは従来通りログ出力で通知

【主な変更点】
- ローディングインジケータが辞書読み込み完了後に正しく非表示になるよう修正
- 入れ替えボタン（swap）をコードから完全に削除し、翻訳元/先の単一方向に固定
- ログエリアのレイアウトを調整して、画面幅によるレイアウト崩れを防止
- 翻訳元言語が recognizedLangs に含まれる場合、翻訳後のタグ配列にその支部タグを先頭に挿入