### PR TITLE
docs: use HTTPS for JP source provenance

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ scp-tag-translation/
 
 ## 辞書の更新方法（開発者向け）
 
-`sources/` のページソースを最新に差し替えた後、以下の順で実行します。
+`sources/` のページソースを HTTPS の出典 URL から最新に差し替えた後、以下の順で実行します。
 
 ```bash
 # 1. ソースを解析して data/ に出力
@@ -97,5 +97,5 @@ Pull Request 大歓迎です。新タグ・新ペアを追加する際は、対�
 **`sources/jp/` 配下のフラグメントファイル**（fragment-basic.txt / fragment-series.txt / fragment-universe.txt / fragment-event.txt / fragment-unused.txt）
 - Title: タグリスト
 - Author: SCP財団
-- Source: http://scp-jp.wikidot.com/tag-list
+- Source: https://scp-jp.wikidot.com/tag-list
 - License: CC BY-SA 3.0 https://creativecommons.org/licenses/by-sa/3.0/legalcode.en

--- a/README.md
+++ b/README.md
@@ -53,6 +53,22 @@ scp-tag-translation/
 ## 辞書の更新方法（開発者向け）
 
 `sources/` のページソースを HTTPS の出典 URL から最新に差し替えた後、以下の順で実行します。
+更新前に、次の `curl` コマンドで JP タグリストの取得経路を確認してください。
+このコマンドは初回 URL とすべてのリダイレクト先で HTTPS 以外を拒否し、応答時間とリダイレクト回数も制限します。
+
+```bash
+curl \
+  --fail --silent --show-error --location \
+  --proto '=https' --proto-redir '=https' \
+  --max-redirs 5 --connect-timeout 10 --max-time 60 \
+  --remove-on-error \
+  --output scp-jp-tag-list.html \
+  'https://scp-jp.wikidot.com/tag-list'
+```
+
+`--proto` と `--proto-redir` はどちらも省略しないでください。前者は初回 URL、後者はすべてのリダイレクト先で HTTPS のみを許可します。
+Wikidot が HTTP へのリダイレクトを返した場合、このコマンドは意図どおり失敗します。HTTP URL に変更したり制約を緩めたりせず、HTTPS のみでページソースを取得できる経路が利用可能になるまで更新を見送ってください。
+コマンドが成功しても、保存される HTML は取得経路の確認用です。ページソースも同じ HTTPS-only 契約で取得し、内容を確認してから対応する節を `sources/jp/fragment-*.txt` に反映します。
 
 ```bash
 # 1. ソースを解析して data/ に出力

--- a/tests/test_readme_source_fetch.py
+++ b/tests/test_readme_source_fetch.py
@@ -1,0 +1,178 @@
+"""README に記載した原典取得コマンドのセキュリティ契約を検証する。"""
+
+import shlex
+import shutil
+import ssl
+import subprocess
+import threading
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+from pathlib import Path
+
+import pytest
+
+
+ROOT = Path(__file__).parent.parent
+README = ROOT / "README.md"
+FETCH_URL = "https://scp-jp.wikidot.com/tag-list"
+OUTPUT_NAME = "scp-jp-tag-list.html"
+
+
+def _documented_curl_command() -> list[str]:
+    readme = README.read_text(encoding="utf-8")
+    start = readme.index("```bash\ncurl ", readme.index("## 辞書の更新方法"))
+    end = readme.index("\n```", start)
+    command = readme[start + len("```bash\n") : end].replace("\\\n", " ")
+    return shlex.split(command)
+
+
+def _option_value(command: list[str], option: str) -> str:
+    return command[command.index(option) + 1]
+
+
+def _probe_command(command: list[str], output: Path, url: str) -> list[str]:
+    probe = command.copy()
+    probe[probe.index("--output") + 1] = str(output)
+    probe[probe.index(FETCH_URL)] = url
+    return probe
+
+
+def test_readme_fetch_command_has_bounded_https_only_contract():
+    command = _documented_curl_command()
+
+    assert command[0] == "curl"
+    assert _option_value(command, "--proto") == "=https"
+    assert _option_value(command, "--proto-redir") == "=https"
+    assert "--location" in command
+    assert _option_value(command, "--max-redirs") == "5"
+    assert _option_value(command, "--connect-timeout") == "10"
+    assert _option_value(command, "--max-time") == "60"
+    assert "--fail" in command
+    assert "--remove-on-error" in command
+    assert _option_value(command, "--output") == OUTPUT_NAME
+    assert command[-1] == FETCH_URL
+
+
+@pytest.mark.skipif(shutil.which("curl") is None, reason="curl is required")
+def test_documented_command_rejects_initial_http_url(tmp_path):
+    output = tmp_path / "initial-http.txt"
+    completed = subprocess.run(
+        _probe_command(
+            _documented_curl_command(),
+            output,
+            "http://127.0.0.1:9/source",
+        ),
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+
+    assert completed.returncode != 0
+    assert not output.exists()
+
+
+class _DowngradeTargetHandler(BaseHTTPRequestHandler):
+    requests = 0
+
+    def do_GET(self):  # noqa: N802 - BaseHTTPRequestHandler API
+        type(self).requests += 1
+        self.send_response(200)
+        self.end_headers()
+        self.wfile.write(b"downgraded")
+
+    def log_message(self, _format, *args):
+        pass
+
+
+class _HttpsRedirectHandler(BaseHTTPRequestHandler):
+    redirect_url = ""
+    requests = 0
+
+    def do_GET(self):  # noqa: N802 - BaseHTTPRequestHandler API
+        type(self).requests += 1
+        self.send_response(302)
+        self.send_header("Location", type(self).redirect_url)
+        self.end_headers()
+
+    def log_message(self, _format, *args):
+        pass
+
+
+def _serve(server: ThreadingHTTPServer):
+    thread = threading.Thread(target=server.serve_forever, daemon=True)
+    thread.start()
+    return thread
+
+
+@pytest.mark.skipif(
+    shutil.which("curl") is None or shutil.which("openssl") is None,
+    reason="curl and openssl are required",
+)
+def test_documented_command_rejects_http_redirect(tmp_path):
+    key = tmp_path / "key.pem"
+    cert = tmp_path / "cert.pem"
+    subprocess.run(
+        [
+            "openssl",
+            "req",
+            "-x509",
+            "-newkey",
+            "rsa:2048",
+            "-nodes",
+            "-subj",
+            "/CN=localhost",
+            "-days",
+            "1",
+            "-keyout",
+            str(key),
+            "-out",
+            str(cert),
+        ],
+        check=True,
+        stdout=subprocess.DEVNULL,
+        stderr=subprocess.DEVNULL,
+    )
+
+    _DowngradeTargetHandler.requests = 0
+    downgrade_server = ThreadingHTTPServer(
+        ("127.0.0.1", 0),
+        _DowngradeTargetHandler,
+    )
+    downgrade_thread = _serve(downgrade_server)
+
+    _HttpsRedirectHandler.requests = 0
+    _HttpsRedirectHandler.redirect_url = (
+        f"http://127.0.0.1:{downgrade_server.server_port}/source"
+    )
+    redirect_server = ThreadingHTTPServer(("127.0.0.1", 0), _HttpsRedirectHandler)
+    tls = ssl.SSLContext(ssl.PROTOCOL_TLS_SERVER)
+    tls.load_cert_chain(cert, key)
+    redirect_server.socket = tls.wrap_socket(redirect_server.socket, server_side=True)
+    redirect_thread = _serve(redirect_server)
+
+    output = tmp_path / "redirect-http.txt"
+    command = _probe_command(
+        _documented_curl_command(),
+        output,
+        f"https://127.0.0.1:{redirect_server.server_port}/source",
+    )
+    command[1:1] = ["--insecure", "--noproxy", "*"]
+
+    try:
+        completed = subprocess.run(
+            command,
+            text=True,
+            capture_output=True,
+            check=False,
+        )
+    finally:
+        redirect_server.shutdown()
+        downgrade_server.shutdown()
+        redirect_thread.join(timeout=5)
+        downgrade_thread.join(timeout=5)
+        redirect_server.server_close()
+        downgrade_server.server_close()
+
+    assert completed.returncode != 0
+    assert _HttpsRedirectHandler.requests == 1
+    assert _DowngradeTargetHandler.requests == 0
+    assert not output.exists()


### PR DESCRIPTION
### Motivation
- The README previously referenced JP Wikidot sources over cleartext `http://` and instructed maintainers to refresh `sources/` from those URLs, which weakens provenance and allows on-path tampering of trusted source data; switching to HTTPS reduces this supply-chain integrity risk.

### Description
- Update `README.md` to instruct maintainers to fetch `sources/` from HTTPS origins and replace the JP source attribution line `Source: http://scp-jp.wikidot.com/tag-list` with `Source: https://scp-jp.wikidot.com/tag-list`.

### Testing
- Ran the project test suite with `python -m pytest`, which passed (`23 passed`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a4fb00b985083268fe8ece95410fd14)