### PR TITLE
Bound concatenated tag splitting

### DIFF
--- a/index.html
+++ b/index.html
@@ -452,40 +452,44 @@
        * 連結タグの最長一致分割
        */
       function splitConcatenatedTags(token, dictionary) {
-        // 辞書キーをチェックしやすいようにセットに変換
-        const dictKeySet = new Set(Object.keys(dictionary));
-        
-        // 動的計画法で最適な分割を見つける
+        const dictKeys = Object.keys(dictionary);
+        const dictKeySet = new Set(dictKeys);
+        const maxKeyLength = dictKeys.reduce(
+          (maxLength, key) => Math.max(maxLength, key.length),
+          0
+        );
+
+        // 動的計画法で最適な分割を見つける。辞書に存在し得ない長さの
+        // 部分文字列は確認しないことで、長い未知トークンの入力時に
+        // UIスレッドが長時間ブロックされるのを防ぐ。
         const n = token.length;
-        
-        // dp[i] = 位置iまでの最適な分割
         const dp = Array(n + 1).fill(null);
         dp[0] = [];
-        
+
         for (let i = 1; i <= n; i++) {
-          for (let j = 0; j < i; j++) {
-            // 部分文字列 j から i までをチェック
+          const minStart = Math.max(0, i - maxKeyLength);
+
+          for (let j = minStart; j < i; j++) {
+            if (dp[j] === null) {
+              continue;
+            }
+
             const segment = token.substring(j, i);
-            
-            // この部分が辞書にあり、j地点までの分割が存在する場合
-            if (dictKeySet.has(segment) && dp[j] !== null) {
+
+            if (dictKeySet.has(segment)) {
               const newSplitCount = dp[j].length + 1;
-              // Prevent potential overflow or negative values
-              if (newSplitCount < 0) {
-              return; 
-              }
               if (dp[i] === null || newSplitCount < dp[i].length) {
-              dp[i] = [...dp[j], segment];
+                dp[i] = [...dp[j], segment];
               }
             }
           }
         }
-        
+
         // 分割できない場合は元のトークンをそのまま返す
         if (dp[n] === null) {
           return [token];
         }
-        
+
         return dp[n];
       }
 


### PR DESCRIPTION
### Motivation
- The previous concatenated-tag splitter scanned every substring of unknown tokens with dynamic programming, allowing an attacker-supplied long token to trigger quadratic-or-worse CPU work and freeze the browser UI thread. 
- The change aims to prevent a client-side denial-of-service induced by pasting very long unrecognized tokens while preserving correct splitting for normal inputs. 

### Description
- Compute `dictKeys` and `maxKeyLength` from the dictionary and build `dictKeySet` to speed lookups. 
- Limit the DP inner-loop start to `const minStart = Math.max(0, i - maxKeyLength)` so only segments that could match dictionary keys are checked. 
- Keep the DP algorithm and the previous behavior of returning the original `token` when no valid split is found. 

### Testing
- Ran a performance check with a 10,000-character unknown token using a Node VM harness which completed quickly and preserved the input, and it succeeded. 
- Ran a functional test in Node verifying that `splitConcatenatedTags('10002000', dictionary)` yields `['1000','2000']`, and it succeeded. 
- Ran repository checks (`git diff --check`) and committed the change; automated checks passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a4fb107d37c8326b2f64cd0719dc722)