### PR TITLE
Harden branch coverage TSV exports

### DIFF
--- a/scripts/assets/branch_tag_coverage.html
+++ b/scripts/assets/branch_tag_coverage.html
@@ -1329,6 +1329,11 @@
         render();
       }
 
+      function hardenSpreadsheetCell(value) {
+        const cell = String(value ?? "").replaceAll("\t", " ").replaceAll("\n", " ");
+        return /^[\s]*[=+\-@]/.test(cell) ? `'${cell}` : cell;
+      }
+
       function exportTsv() {
         const rows = sortRows(filteredRows());
         const headers = ["branch", "tag", "status", "translation_action", "copy_allowed", "jp_tag", "replacement", "page_count", "rank", "sample_slugs"];
@@ -1338,7 +1343,7 @@
             headers
               .map((key) => {
                 const value = key === "sample_slugs" ? (row.sample_slugs || []).join(",") : row[key];
-                return String(value ?? "").replaceAll("\t", " ").replaceAll("\n", " ");
+                return hardenSpreadsheetCell(value);
               })
               .join("\t"),
           );

--- a/scripts/commands/build_branch_tag_coverage_data.py
+++ b/scripts/commands/build_branch_tag_coverage_data.py
@@ -70,6 +70,17 @@ ACTION_DESCRIPTIONS: dict[CoverageTranslationAction, str] = {
     "tag_application_required": "No JP tag-list mapping; omit and request/confirm a JP tag before use.",
 }
 
+FORMULA_PREFIX_CHARS = ("=", "+", "-", "@")
+
+
+def harden_spreadsheet_cell(value: object) -> str:
+    """Return a TSV/CSV cell safe to open in spreadsheet applications."""
+    cell = str(value)
+    if cell.lstrip().startswith(FORMULA_PREFIX_CHARS):
+        return f"'{cell}"
+    return cell
+
+
 
 def write_json(path: Path, data: Mapping[str, object]) -> None:
     path.parent.mkdir(parents=True, exist_ok=True)
@@ -371,20 +382,26 @@ def write_tsv(path: Path, coverage: Coverage) -> None:
             branch = branch_entry["branch"]
             for tag_entry in branch_entry["tags"]:
                 writer.writerow({
-                    "branch": branch,
-                    "tag": tag_entry["tag"],
+                    "branch": harden_spreadsheet_cell(branch),
+                    "tag": harden_spreadsheet_cell(tag_entry["tag"]),
                     "rank": tag_entry["rank"],
                     "page_count": tag_entry["page_count"],
-                    "status": tag_entry["status"],
+                    "status": harden_spreadsheet_cell(tag_entry["status"]),
                     "recognized_by_jp_policy": str(
                         tag_entry["recognized_by_jp_policy"]
                     ).lower(),
-                    "jp_tag": tag_entry["jp_tag"] or "",
-                    "replacement": tag_entry["replacement"] or "",
-                    "translation_action": tag_entry["translation_action"],
+                    "jp_tag": harden_spreadsheet_cell(tag_entry["jp_tag"] or ""),
+                    "replacement": harden_spreadsheet_cell(tag_entry["replacement"] or ""),
+                    "translation_action": harden_spreadsheet_cell(
+                        tag_entry["translation_action"]
+                    ),
                     "copy_allowed": str(tag_entry["copy_allowed"]).lower(),
-                    "display_tag": tag_entry["display_tag"] or "",
-                    "sample_slugs": ",".join(tag_entry["sample_slugs"]),
+                    "display_tag": harden_spreadsheet_cell(
+                        tag_entry["display_tag"] or ""
+                    ),
+                    "sample_slugs": harden_spreadsheet_cell(
+                        ",".join(tag_entry["sample_slugs"])
+                    ),
                 })
 
 
@@ -436,12 +453,14 @@ def write_application_tsv(path: Path, inventory: ApplicationInventory) -> None:
         for branch_entry in inventory["branches"]:
             for tag_entry in branch_entry["tags"]:
                 writer.writerow({
-                    "site": branch_entry["site"],
-                    "branch": branch_entry["branch"],
-                    "source_tag": tag_entry["tag"],
-                    "display_tag": tag_entry["display_tag"],
+                    "site": harden_spreadsheet_cell(branch_entry["site"]),
+                    "branch": harden_spreadsheet_cell(branch_entry["branch"]),
+                    "source_tag": harden_spreadsheet_cell(tag_entry["tag"]),
+                    "display_tag": harden_spreadsheet_cell(tag_entry["display_tag"]),
                     "page_count": tag_entry["page_count"],
-                    "sample_slugs": ",".join(tag_entry["sample_slugs"]),
+                    "sample_slugs": harden_spreadsheet_cell(
+                        ",".join(tag_entry["sample_slugs"])
+                    ),
                 })
 
 

--- a/tests/test_branch_tag_coverage.py
+++ b/tests/test_branch_tag_coverage.py
@@ -177,3 +177,77 @@ def test_coverage_main_reports_publication_failure(
         "エラー: 可視化データ生成に失敗しました: disk full\n"
     )
     assert not (tmp_path / "output").exists()
+
+
+def test_write_tsv_hardens_spreadsheet_formula_cells(tmp_path):
+    output = tmp_path / "coverage.tsv"
+    coverage_builder.write_tsv(
+        output,
+        {
+            "schema_version": 1,
+            "source": {},
+            "status_descriptions": {},
+            "action_descriptions": {},
+            "branches": [
+                {
+                    "branch": "en",
+                    "site": "scp-wiki.net",
+                    "page_count": 1,
+                    "tag_count": 1,
+                    "status_counts": {},
+                    "tags": [
+                        {
+                            "tag": "=1+1",
+                            "rank": 1,
+                            "page_count": 1,
+                            "status": "unhandled",
+                            "recognized_by_jp_policy": False,
+                            "jp_tag": "+jp",
+                            "replacement": " -replacement",
+                            "translation_action": "tag_application_required",
+                            "copy_allowed": False,
+                            "display_tag": "@display",
+                            "target_policy": None,
+                            "sample_slugs": ["@SUM(1)", "safe"],
+                        }
+                    ],
+                }
+            ],
+        },
+    )
+
+    assert output.read_text(encoding="utf-8").splitlines()[1] == (
+        "en\t'=1+1\t1\t1\tunhandled\tfalse\t'+jp\t' -replacement\t"
+        "tag_application_required\tfalse\t'@display\t'@SUM(1),safe"
+    )
+
+
+def test_write_application_tsv_hardens_spreadsheet_formula_cells(tmp_path):
+    output = tmp_path / "application.tsv"
+    coverage_builder.write_application_tsv(
+        output,
+        {
+            "schema_version": 1,
+            "rule": "test",
+            "branches": [
+                {
+                    "site": "=site",
+                    "branch": "+branch",
+                    "scanned_page_count": 1,
+                    "tag_count": 1,
+                    "tags": [
+                        {
+                            "tag": "-tag",
+                            "display_tag": "@display",
+                            "page_count": 1,
+                            "sample_slugs": ["=slug"],
+                        }
+                    ],
+                }
+            ],
+        },
+    )
+
+    assert output.read_text(encoding="utf-8").splitlines()[1] == (
+        "'=site\t'+branch\t'-tag\t'@display\t1\t'=slug"
+    )

--- a/tests/test_branch_tag_coverage_artifacts.py
+++ b/tests/test_branch_tag_coverage_artifacts.py
@@ -47,20 +47,28 @@ def test_visualization_tsv_exactly_matches_json(coverage):
     for branch in coverage["branches"]:
         for entry in branch["tags"]:
             expected_rows.append({
-                "branch": branch["branch"],
-                "tag": entry["tag"],
+                "branch": coverage_builder.harden_spreadsheet_cell(branch["branch"]),
+                "tag": coverage_builder.harden_spreadsheet_cell(entry["tag"]),
                 "rank": str(entry["rank"]),
                 "page_count": str(entry["page_count"]),
-                "status": entry["status"],
+                "status": coverage_builder.harden_spreadsheet_cell(entry["status"]),
                 "recognized_by_jp_policy": str(
                     entry["recognized_by_jp_policy"]
                 ).lower(),
-                "jp_tag": entry["jp_tag"] or "",
-                "replacement": entry["replacement"] or "",
-                "translation_action": entry["translation_action"],
+                "jp_tag": coverage_builder.harden_spreadsheet_cell(entry["jp_tag"] or ""),
+                "replacement": coverage_builder.harden_spreadsheet_cell(
+                    entry["replacement"] or ""
+                ),
+                "translation_action": coverage_builder.harden_spreadsheet_cell(
+                    entry["translation_action"]
+                ),
                 "copy_allowed": str(entry["copy_allowed"]).lower(),
-                "display_tag": entry["display_tag"] or "",
-                "sample_slugs": ",".join(entry["sample_slugs"]),
+                "display_tag": coverage_builder.harden_spreadsheet_cell(
+                    entry["display_tag"] or ""
+                ),
+                "sample_slugs": coverage_builder.harden_spreadsheet_cell(
+                    ",".join(entry["sample_slugs"])
+                ),
             })
 
     with COVERAGE_TSV.open(encoding="utf-8", newline="") as f:
@@ -108,12 +116,14 @@ def test_application_inventory_exactly_matches_unhandled_coverage(coverage):
         rows = list(csv.DictReader(f, delimiter="\t"))
     expected_rows = [
         {
-            "site": branch["site"],
-            "branch": branch["branch"],
-            "source_tag": entry["tag"],
-            "display_tag": entry["display_tag"],
+            "site": coverage_builder.harden_spreadsheet_cell(branch["site"]),
+            "branch": coverage_builder.harden_spreadsheet_cell(branch["branch"]),
+            "source_tag": coverage_builder.harden_spreadsheet_cell(entry["tag"]),
+            "display_tag": coverage_builder.harden_spreadsheet_cell(entry["display_tag"]),
             "page_count": str(entry["page_count"]),
-            "sample_slugs": ",".join(entry["sample_slugs"]),
+            "sample_slugs": coverage_builder.harden_spreadsheet_cell(
+                ",".join(entry["sample_slugs"])
+            ),
         }
         for branch in inventory["branches"]
         for entry in branch["tags"]

--- a/tests/test_branch_tag_coverage_html.py
+++ b/tests/test_branch_tag_coverage_html.py
@@ -252,3 +252,11 @@ def test_coverage_html_main_preserves_output_on_publication_failure(
         "エラー: HTML可視化生成に失敗しました: disk full\n"
     )
     assert output.read_text(encoding="utf-8") == "previous"
+
+
+def test_dashboard_export_hardens_spreadsheet_formula_cells():
+    template = TEMPLATE_HTML.read_text(encoding="utf-8")
+
+    assert "function hardenSpreadsheetCell" in template
+    assert "return /^[\\s]*[=+\\-@]/.test(cell) ? `'${cell}` : cell;" in template
+    assert "return hardenSpreadsheetCell(value);" in template

--- a/visualization/branch_tag_coverage.tsv
+++ b/visualization/branch_tag_coverage.tsv
@@ -1173,7 +1173,7 @@ cn	肖邦教	1171	7	unhandled	false			tag_application_required	false	未訳-肖�
 cn	舌尖	1172	7	unhandled	false			tag_application_required	false	未訳-舌尖	a-bit-of-inferior-product-1,a-bite-of-hensec,day-of-fatass,eggtart,eggtart1
 cn	藏枪教会	1173	7	official_crosswalk	false	懐中銃教会		copy	true	懐中銃教会	entretiens-avec-de-potentiels-nouveaux-dieux,scp-1074-jp,scp-2424-jp,scp-457-jp,scp-cn-3507
 cn	角磨机	1174	7	official_crosswalk	false	角度研削者		copy	true	角度研削者	mtf-theta-90-character-profiles,mtf-theta-90-hub-page,scp-1707,scp-3307,scp-4037
-cn	-500	1175	6	jp_tag_alias	true	500語未満コンテスト		copy	true	500語未満コンテスト	scp-103-fr,scp-113-fr,scp-119-fr,scp-155-fr,scp-192-fr
+cn	'-500	1175	6	jp_tag_alias	true	500語未満コンテスト		copy	true	500語未満コンテスト	scp-103-fr,scp-113-fr,scp-119-fr,scp-155-fr,scp-192-fr
 cn	2013短篇故事竞赛	1176	6	unhandled	false			tag_application_required	false	未訳-2013短篇故事竞赛	la-hija-bien-amada,navidad-antartica-de-gauss-castillo-y-trash,noche-tranquila-en-sitio-34,scp-1millon,suenos-navidenos
 cn	2019回收竞赛	1177	6	official_crosswalk	false	リサイクル2019		copy	true	リサイクル2019	jiraku-ogakuzu-yzkrt-proposal-j,scp-1494-jp,scp-1551-jp,scp-1598-jp,scp-1637-jp
 cn	2021十五夜团子祭	1178	6	unhandled	false			tag_application_required	false	未訳-2021十五夜团子祭	kitei-disease,koigarezaki-news-20210809,scp-2288-jp,scp-2655-jp,scp-837-jp
@@ -4982,7 +4982,7 @@ es	dr-torayar	718	5	unhandled	false			tag_application_required	false	未訳-dr-t
 es	el-ingeniero	719	5	official_crosswalk	false	エンジニア		copy	true	エンジニア	burned-a-hole-in-my-mind,djkaktus-s-proposal-iii,footage-recovered-from-a-private-server,sc-02-000-22-000,static-in-my-attic
 es	esciúrido	720	5	official_crosswalk	false	齧歯類		copy	true	齧歯類	scp-1845,scp-2050,scp-2797,scp-3761,scp-es-089
 es	gdicon-2024	721	5	unhandled	false			tag_application_required	false	未訳-gdicon-2024	camila,concurso-gdi-es-2024,la-promesa,manifesto793,testimonio-de-un-contacto-particular
-es	glacon	722	5	official_crosswalk	false	グラソン		copy	true	グラソン	alert-lockdown-initiated,clock-multiplier,command-query-separation,null-terminating-string,superencipherment
+es	'-500	749	4	jp_tag_alias	true	500語未満コンテスト		copy	true	500語未満コンテスト	scp-103-fr,scp-113-fr,scp-119-fr,scp-155-fr
 es	halyna-ieva	723	5	official_crosswalk	false	ハリーナ・イエヴァ		copy	true	ハリーナ・イエヴァ	another-soul-joins-the-halkost,et-ecce,mother-who-demands-ones-toes,scp-5509,tifu-by-getting-a-book-from-the-library
 es	idea2018	724	5	unhandled	false			tag_application_required	false	未訳-idea2018	idea2018,scp-es-052,scp-es-062,scp-es-064,scp-es-073
 es	investigador-james	725	5	official_crosswalk	false	ジェームズ研究員		copy	true	ジェームズ研究員	recording-stuff-or-whatever,scp-078-j,scp-789-j,scp-8231-j,scp-9726
@@ -14718,8 +14718,8 @@ zh-tr	得獎展出	905	2	unhandled	false			tag_application_required	false	未訳
 zh-tr	心宿二協會	906	2	official_crosswalk	false	アンタレス協会		copy	true	アンタレス協会	fragmentos-traducidos-del-libro-de-la-vida,informe-sobre-la-sociedad-antares
 zh-tr	政治	907	2	unhandled	false			tag_application_required	false	未訳-政治	matryoshka-epilogue,the-woodvale-incident
 zh-tr	教會聖師	908	2	official_crosswalk	false	教会の博士		copy	true	教会の博士	doctors-of-the-church-hub,quid-est-non-scitum
-zh-tr	散文	909	2	unhandled	false			tag_application_required	false	未訳-散文	flash-fiction-collection-one,wanderers:all-astronauts-go-to-heaven
-zh-tr	敬持聖杯之影	910	2	unhandled	false			tag_application_required	false	未訳-敬持聖杯之影	artwork-of-rose-and-bronze,holding-grails-hub
+zh-tr	'+_普羅米修斯實驗室-goi格式	936	1	unhandled	false			tag_application_required	false	未訳-+_普羅米修斯實驗室-goi格式	grant-request-for-the-telekinetic-alloy
+zh-tr	'+_毆打鯊魚中心-goi格式	937	1	unhandled	false			tag_application_required	false	未訳-+_毆打鯊魚中心-goi格式	ting129-s-ko-proposal
 zh-tr	整合計畫	911	2	unhandled	false			tag_application_required	false	未訳-整合計畫	scp-7999,scp-9595
 zh-tr	文件	912	2	unhandled	false			tag_application_required	false	未訳-文件	scp-1045-jp,scp-1161
 zh-tr	有村組	913	2	jp_tag_name	true	有村組		copy	true	有村組	scp-2042-jp,scp-3060-jp

--- a/visualization/tag_application_inventory.tsv
+++ b/visualization/tag_application_inventory.tsv
@@ -5472,8 +5472,8 @@ scp-zh-tr	zh-tr	thorn	未訳-thorn	2	wanderers:a-suicide-note,wanderers:nigerian
 scp-zh-tr	zh-tr	vang博士	未訳-vang博士	2	in-his-own-image-part-4,scp-j
 scp-zh-tr	zh-tr	workplace	未訳-workplace	2	wanderers:the-chariot,wanderers:the-hermit
 scp-zh-tr	zh-tr	中心頁	未訳-中心頁	2	admonition,nue-hub
-scp-zh-tr	zh-tr	他宇宙	未訳-他宇宙	2	a-wandsman-in-the-court-of-the-hanged-king,beasts-of-the-old-letters
-scp-zh-tr	zh-tr	個體	未訳-個體	2	wanderers:citizen-report,wanderers:the-study-of-ancient-spells
+scp-zh-tr	zh-tr	'+_普羅米修斯實驗室-goi格式	未訳-+_普羅米修斯實驗室-goi格式	1	grant-request-for-the-telekinetic-alloy
+scp-zh-tr	zh-tr	'+_毆打鯊魚中心-goi格式	未訳-+_毆打鯊魚中心-goi格式	1	ting129-s-ko-proposal
 scp-zh-tr	zh-tr	光	未訳-光	2	scp-189-ko,scp-zh-642
 scp-zh-tr	zh-tr	區域性	未訳-區域性	2	scp-zh-500,scp-zh-500-arc
 scp-zh-tr	zh-tr	可重寫	未訳-可重寫	2	scp-1178,scp-4791


### PR DESCRIPTION
### Motivation
- The branch coverage TSV writer and the dashboard's browser TSV export emitted corpus-derived strings (tags, JP tags, replacements, sample slugs) verbatim, allowing spreadsheet formula-injection when cells begin with `=`, `+`, `-`, or `@`.
- The committed visualization artifacts already contained formula-leading cells, so a minimal hardening is required to neutralize these values before they are written or downloaded.

### Description
- Add a shared Python helper `harden_spreadsheet_cell()` and `FORMULA_PREFIX_CHARS` in `scripts/commands/build_branch_tag_coverage_data.py` that prefixes cells beginning with optional whitespace followed by `=`, `+`, `-`, or `@` with a single apostrophe.
- Apply `harden_spreadsheet_cell()` to all string-like TSV cells produced by `write_tsv()` and `write_application_tsv()` so `tag`, `jp_tag`, `replacement`, `display_tag`, `sample_slugs`, `site`, and `branch` are neutralized before writing.
- Harden the browser-side TSV export by adding `hardenSpreadsheetCell()` into the HTML template (`scripts/assets/branch_tag_coverage.html`) and using it in the `exportTsv()` logic to sanitize values before creating the downloadable `Blob`.
- Regenerate the committed visualization artifacts (`visualization/branch_tag_coverage.tsv`, `visualization/tag_application_inventory.tsv`, and HTML) and update tests to assert the hardened outputs and the presence of the dashboard export helper.

### Testing
- Ran targeted tests for the change (`tests/test_branch_tag_coverage.py` and `tests/test_branch_tag_coverage_html.py`) which passed locally after the change; added regression tests that assert TSV hardening.
- Ran the full test suite with `python -m pytest` and observed all automated tests succeeding (`206 passed, 1 skipped`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a5547a9280c83268f5dd4c17a91d4df)