### PR TITLE
Fix EN dictionary source mapping precedence

### DIFF
--- a/scripts/commands/build_dict.py
+++ b/scripts/commands/build_dict.py
@@ -85,7 +85,7 @@ def build(
     existing: dict[str, str | None] | None = None,
     deprecated_en_tags: set[str] | None = None,
 ) -> dict[str, str | None]:
-    """Treat existing mappings as compatibility overrides; deprecation still wins."""
+    """Preserve existing manual mappings only when JP source data has no mapping."""
     if existing is None:
         existing = {}
     if deprecated_en_tags is None:
@@ -103,6 +103,8 @@ def build(
         source_tag: target
         for source_tag, target in existing.items()
         if target is not None
+        and source_tag not in jp_names
+        and source_tag not in jp_source_map
     }
     policy = MappingPolicy(
         jp_names=jp_names,

--- a/tests/test_build_dict.py
+++ b/tests/test_build_dict.py
@@ -50,6 +50,12 @@ def test_existing_manual_preserved():
     assert result["hub"] == "ハブ"
 
 
+def test_jp_source_mapping_overrides_existing_manual_value():
+    existing = {"tale": "scp"}
+    result = build(EN, JP, existing)
+    assert result["tale"] == "テイル"
+
+
 def test_jp_overrides_null_existing():
     existing = {"scp": None}
     result = build(EN, JP, existing)


### PR DESCRIPTION
### Motivation
- A recent change treated all existing non-null EN dictionary entries as branch overrides, which made stale or manual values win over authoritative JP tag-name and JP `source_tags` mappings and weakened generated dictionary integrity.
- The intent is to preserve manual entries only when the JP data provides no mapping for the source tag.

### Description
- Adjust `build()` in `scripts/commands/build_dict.py` so `compatibility_overrides` includes an existing mapping only if the `source_tag` is not present in `jp_names` and not present in `jp_source_map`.
- Update the `build()` docstring to reflect the new precedence semantics.
- Add a regression test `test_jp_source_mapping_overrides_existing_manual_value` in `tests/test_build_dict.py` to assert a JP source-derived mapping overrides a stale existing dictionary value.

### Testing
- Ran `pytest tests/test_build_dict.py`, which passed all tests in that file.
- Ran the full suite with `pytest`, which completed successfully (all tests passed except expected skips).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a554413c61883269590eac88dab7d8e)