### PR TITLE
Validate coverage protocol field types

### DIFF
--- a/scripts/domain/tag_validation.py
+++ b/scripts/domain/tag_validation.py
@@ -298,6 +298,10 @@ def _validate_jp_policy(value: object, context: str) -> None:
         f"{context}.target_policy",
     )
     action = value.get("special_translation_action")
+    if action is not None and not isinstance(action, str):
+        raise ValueError(
+            f"{context}.target_policy.special_translation_action must be a string or null"
+        )
     if action is not None and action not in SPECIAL_TRANSLATION_ACTIONS:
         raise ValueError(
             f"{context}.target_policy.special_translation_action is invalid"
@@ -314,9 +318,15 @@ def _validate_coverage_tag(value: object, context: str) -> None:
     )
     if not isinstance(value.get("tag"), str):
         raise ValueError(f"{context}.tag must be a string")
-    if value.get("status") not in CLASSIFICATION_STATUSES:
+    status = value.get("status")
+    if not isinstance(status, str):
+        raise ValueError(f"{context}.status must be a string")
+    if status not in CLASSIFICATION_STATUSES:
         raise ValueError(f"{context}.status is unknown")
-    if value.get("translation_action") not in COVERAGE_TRANSLATION_ACTIONS:
+    translation_action = value.get("translation_action")
+    if not isinstance(translation_action, str):
+        raise ValueError(f"{context}.translation_action must be a string")
+    if translation_action not in COVERAGE_TRANSLATION_ACTIONS:
         raise ValueError(f"{context}.translation_action is unknown")
     _validate_required_boolean_fields(
         value,

--- a/tests/test_branch_tag_coverage.py
+++ b/tests/test_branch_tag_coverage.py
@@ -4,6 +4,7 @@ import pytest
 
 from scripts.commands import build_branch_tag_coverage_data as coverage_builder
 from scripts.domain import tag_policy
+from scripts.domain.tag_validation import validate_coverage
 
 
 def test_classify_tag_distinguishes_jp_list_and_override_states():
@@ -177,3 +178,98 @@ def test_coverage_main_reports_publication_failure(
         "エラー: 可視化データ生成に失敗しました: disk full\n"
     )
     assert not (tmp_path / "output").exists()
+
+
+def _minimal_coverage_tag():
+    return {
+        "tag": "scp",
+        "status": "jp_tag_name",
+        "recognized_by_jp_policy": True,
+        "jp_tag": "scp",
+        "replacement": None,
+        "translation_action": "copy",
+        "copy_allowed": True,
+        "display_tag": "scp",
+        "rank": 1,
+        "page_count": 1,
+        "sample_slugs": ["sample"],
+        "target_policy": {
+            "use_restricted": False,
+            "edit_restricted": False,
+            "translation_exempt": False,
+            "copy_allowed_for_translation": True,
+            "special_translation_action": None,
+        },
+    }
+
+
+def _minimal_coverage_document(tag):
+    return {
+        "schema_version": 1,
+        "source": {
+            "corpus_root": "corpus",
+            "jp_tag_source": "jp",
+            "jp_unused_source": "unused",
+            "override_source": "override",
+            "deprecated_override_source": "deprecated",
+            "crosswalk_source": "crosswalk",
+        },
+        "status_descriptions": {
+            "jp_unused_replacement": "",
+            "jp_unused_no_single_replacement": "",
+            "jp_translation_policy_omit": "",
+            "jp_tag_name": "",
+            "jp_tag_alias": "",
+            "curated_override_only": "",
+            "official_crosswalk": "",
+            "unhandled": "",
+        },
+        "action_descriptions": {
+            "copy": "",
+            "copy_replacement": "",
+            "omit_jp_policy": "",
+            "omit_jp_unused": "",
+            "omit_translation_policy": "",
+            "staff_permission_required": "",
+            "tag_application_required": "",
+        },
+        "branches": [{
+            "branch": "en",
+            "site": "EN",
+            "page_count": 1,
+            "tag_count": 1,
+            "status_counts": {
+                "jp_unused_replacement": 0,
+                "jp_unused_no_single_replacement": 0,
+                "jp_translation_policy_omit": 0,
+                "jp_tag_name": 1,
+                "jp_tag_alias": 0,
+                "curated_override_only": 0,
+                "official_crosswalk": 0,
+                "unhandled": 0,
+            },
+            "tags": [tag],
+        }],
+    }
+
+
+@pytest.mark.parametrize(
+    ("field_path", "message"),
+    [
+        (("status",), "status must be a string"),
+        (("translation_action",), "translation_action must be a string"),
+        (
+            ("target_policy", "special_translation_action"),
+            "special_translation_action must be a string or null",
+        ),
+    ],
+)
+def test_validate_coverage_rejects_unhashable_protocol_fields(field_path, message):
+    tag = _minimal_coverage_tag()
+    target = tag
+    for key in field_path[:-1]:
+        target = target[key]
+    target[field_path[-1]] = []
+
+    with pytest.raises(ValueError, match=message):
+        validate_coverage(_minimal_coverage_document(tag))


### PR DESCRIPTION
### Motivation
- The coverage validator performed frozenset membership tests directly on JSON fields like `status`, `translation_action`, and `target_policy.special_translation_action`, which caused `TypeError` for unhashable non-string JSON values instead of a controlled `ValueError`.
- The HTML builder CLI only catches `OSError` and `ValueError`, so those `TypeError` exceptions could abort visualization generation with an uncaught traceback.

### Description
- Add an explicit type check in `_validate_jp_policy` to ensure `special_translation_action` is `None` or a `str` before checking membership against `SPECIAL_TRANSLATION_ACTIONS`.
- Add explicit type checks in `_validate_coverage_tag` for `status` and `translation_action` to require strings before testing membership against `CLASSIFICATION_STATUSES` and `COVERAGE_TRANSLATION_ACTIONS`.
- Preserve the existing unknown-value `ValueError` messages so unknown strings are still rejected as before.
- Add a regression test `test_validate_coverage_rejects_unhashable_protocol_fields` in `tests/test_branch_tag_coverage.py` to assert malformed unhashable protocol fields raise `ValueError` with appropriate messages.

### Testing
- Ran `python -m pytest tests/test_branch_tag_coverage.py` and the file's tests passed (including the new parametrized cases).
- Ran the full test suite with `python -m pytest` and observed all tests passing (206 passed, 1 skipped).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a55451268508326b75962f9a64f9d5f)